### PR TITLE
Fix typos in ClassBuilder

### DIFF
--- a/lib/rom/support/class_builder.rb
+++ b/lib/rom/support/class_builder.rb
@@ -13,7 +13,7 @@ module ROM
     # Generate a class based on options
     #
     # @example
-    #   builder = ROM::ClasBuilder.new(name: 'MyClass')
+    #   builder = ROM::ClassBuilder.new(name: 'MyClass')
     #
     #   klass = builder.call
     #   klass.name # => "MyClass"

--- a/lib/rom/support/class_builder.rb
+++ b/lib/rom/support/class_builder.rb
@@ -8,7 +8,7 @@ module ROM
     include Options
 
     option :name, type: String, reader: true
-    option :parent, type: Class, reader: true, parent: Object
+    option :parent, type: Class, reader: true, default: Object
 
     # Generate a class based on options
     #


### PR DESCRIPTION
This fixes a typo in the ClassBuilder documentation and one in the
implementation of the `:parent` option, where a default was not set if
a `:parent` option was not specified.
