### PR TITLE
Add support for `:coercer` option key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
-v0.1.0 2015-08-10
+## v0.1.1 to be released
+
+### Added
+
+* Support for `:coercer` option key (nepalez)
+
+## v0.1.0 2015-08-10
 
 First public release. The code was ported from rom 0.8.1

--- a/Gemfile
+++ b/Gemfile
@@ -33,3 +33,5 @@ group :tools do
     gem 'mutant-rspec'
   end
 end
+
+gem 'transproc', github: 'solnic/transproc'

--- a/Gemfile
+++ b/Gemfile
@@ -34,5 +34,3 @@ group :tools do
     gem 'mutant-rspec'
   end
 end
-
-gem 'transproc', github: 'solnic/transproc'

--- a/spec/unit/rom/support/options_spec.rb
+++ b/spec/unit/rom/support/options_spec.rb
@@ -88,6 +88,22 @@ describe ROM::Options do
       expect(object.options).to eql(args: nil)
     end
 
+    it 'coerces assigned values' do
+      klass.option :number, coercer: -> v { v.to_i }
+
+      object = klass.new(number: '1')
+
+      expect(object.options).to eql(number: 1)
+    end
+
+    it 'not coerces default values' do
+      klass.option :number, default: '1', coercer: -> v { v.to_i }
+
+      object = klass.new
+
+      expect(object.options).to eql(number: '1')
+    end
+
     it 'options are frozen' do
       object = klass.new
 


### PR DESCRIPTION
The coercer is applied to assigned values only:

``` ruby
class Age
  include ROM::Options
  option :value, reader: true, default: 'unknown', coercer: -> v { v.to_i }
end

age = Age.new
age.value # => 'unknown' (not coerced)

age = Age.new value: '1'
age.value # => 1 (coerced)
```

The coercer should respond to `#call` (as usual :wink:). For example, I'm using this in a `rom-migrator` to convert paths to absolute:

``` ruby
option :path,  reader: true, coercer: File.method(:expand_path)
option :template, reader: true, coercer: File.method(:expand_path)
```
