### PR TITLE
Require transproc

### DIFF
--- a/lib/rom/support/options.rb
+++ b/lib/rom/support/options.rb
@@ -1,3 +1,5 @@
+require 'transproc'
+
 module ROM
   # Helper module for classes with a constructor accepting option hash
   #


### PR DESCRIPTION
Since #2 I'm getting 

```
uninitialized constant ROM::Options::Transformers::Transproc (NameError)
```
