### PR TITLE
Add runtime dependency from transproc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'transproc', github: 'solnic/transproc', branch: 'master'
+gem 'transproc',  github: 'solnic/transproc',  branch: 'master'
 gem 'rom-mapper', github: 'rom-rb/rom-mapper', branch: 'master'
 
 group :console do

--- a/rom-support.gemspec
+++ b/rom-support.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_runtime_dependency 'wisper', '~> 1.6', '>= 1.6.0'
+  gem.add_runtime_dependency 'transproc', '~> 0.4.0'
 
   gem.add_development_dependency 'rake', '~> 10.3'
   gem.add_development_dependency 'rspec', '~> 3.3'


### PR DESCRIPTION
Seems like we have a circular dependency between `rom-support` and `rom-mapper`
