### PR TITLE
Add support for default value in ROM::Registry#fetch

### DIFF
--- a/lib/rom/support/registry.rb
+++ b/lib/rom/support/registry.rb
@@ -26,9 +26,14 @@ module ROM
       elements.key?(name)
     end
 
-    def [](key)
-      elements.fetch(key) { raise ElementNotFoundError.new(key, name) }
+    def fetch(key)
+      elements.fetch(key) do
+        return yield if block_given?
+
+        raise ElementNotFoundError.new(key, name)
+      end
     end
+    alias_method :[], :fetch
 
     def respond_to_missing?(name, include_private = false)
       elements.key?(name) || super

--- a/spec/unit/rom/support/registry_spec.rb
+++ b/spec/unit/rom/support/registry_spec.rb
@@ -1,6 +1,25 @@
 require 'spec_helper'
 require 'rom/support/registry'
 
+shared_examples_for 'registry fetch' do
+  it 'returns registered element identified by name' do
+    expect(registry.public_send(fetch_method, :mars)).to be(mars)
+  end
+
+  it 'raises error when element is not found' do
+    expect { registry.public_send(fetch_method, :twix) }.to raise_error(
+      ROM::Registry::ElementNotFoundError,
+      ":twix doesn't exist in Candy registry"
+    )
+  end
+
+  it 'returns the value from an optional block when key is not found' do
+    value = registry.public_send(fetch_method, :candy) { :twix }
+
+    expect(value).to eq(:twix)
+  end
+end
+
 describe ROM::Registry do
   subject(:registry) { registry_class.new(mars: mars) }
 
@@ -15,31 +34,20 @@ describe ROM::Registry do
   end
 
   describe '#fetch' do
-    it 'has an alias to []' do
-      expect(registry.method(:fetch)).to eq(registry.method(:[]))
-    end
+    let(:fetch_method) { :fetch }
 
-    it 'returns registered elemented identified by name' do
-      expect(registry.fetch(:mars)).to be(mars)
-    end
-
-    it 'raises error when element is not found' do
-      expect { registry.fetch(:twix) }.to raise_error(
-        ROM::Registry::ElementNotFoundError,
-        ":twix doesn't exist in Candy registry"
-      )
-    end
-
-    it 'returns the value from an optional block when key is not found' do
-      value = registry.fetch(:candy) { :twix }
-
-      expect(value).to eq(:twix)
-    end
+    it_behaves_like 'registry fetch'
   end
 
-  describe '.element_name' do
-    it 'returns registered elemented identified by element_name' do
-      expect(registry[:mars]).to be(mars)
+  describe '#[]' do
+    let(:fetch_method) { :[] }
+
+    it_behaves_like 'registry fetch'
+  end
+
+  describe '#method_missing' do
+    it 'returns registered element identified by name' do
+      expect(registry.mars).to be(mars)
     end
 
     it 'raises no-method error when element is not there' do

--- a/spec/unit/rom/support/registry_spec.rb
+++ b/spec/unit/rom/support/registry_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'rom/support/registry'
+
+describe ROM::Registry do
+  subject(:registry) { registry_class.new(mars: mars) }
+
+  let(:mars) { double('mars') }
+
+  let(:registry_class) do
+    Class.new(ROM::Registry) do
+      def self.name
+        'Candy'
+      end
+    end
+  end
+
+  describe '#fetch' do
+    it 'returns registered elemented identified by name' do
+      expect(registry[:mars]).to be(mars)
+    end
+
+    it 'raises error when element is not found' do
+      expect { registry[:twix] }.to raise_error(
+        ROM::Registry::ElementNotFoundError,
+        ":twix doesn't exist in Candy registry"
+      )
+    end
+  end
+
+  describe '.element_name' do
+    it 'returns registered elemented identified by element_name' do
+      expect(registry[:mars]).to be(mars)
+    end
+
+    it 'raises no-method error when element is not there' do
+      expect { registry.twix }.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/unit/rom/support/registry_spec.rb
+++ b/spec/unit/rom/support/registry_spec.rb
@@ -15,15 +15,25 @@ describe ROM::Registry do
   end
 
   describe '#fetch' do
+    it 'has an alias to []' do
+      expect(registry.method(:fetch)).to eq(registry.method(:[]))
+    end
+
     it 'returns registered elemented identified by name' do
-      expect(registry[:mars]).to be(mars)
+      expect(registry.fetch(:mars)).to be(mars)
     end
 
     it 'raises error when element is not found' do
-      expect { registry[:twix] }.to raise_error(
+      expect { registry.fetch(:twix) }.to raise_error(
         ROM::Registry::ElementNotFoundError,
         ":twix doesn't exist in Candy registry"
       )
+    end
+
+    it 'returns the value from an optional block when key is not found' do
+      value = registry.fetch(:candy) { :twix }
+
+      expect(value).to eq(:twix)
     end
   end
 


### PR DESCRIPTION
This pull request is part of the following issue: https://github.com/rom-rb/rom/issues/324

 I've updated `ROM::Registry#fetch` implementation to work in a similar fashion to Ruby's `Hash#fetch`, so that it accepts a block as a default value provider. This change makes it possible to throw specialized exceptions when fetching elements from the registry, as well as returning default values when the key does not exist. I guess this will be mostly used to throw exceptions.
- I'm moving `ROM::Registry` specs from the main `rom` repo, because the code for `ROM::Registry` is here in this repo.
- I'm renaming `[]` to `fetch`, because Ruby does not accept blocks when working with
  square bracket methods. So `fetch` will be used as an alternative to `[]`.
  
  ``` ruby
  # Does not work
  registry[:foo] { :default }
  
  # Does not work either
  registry.[](:foo) { :default }
  ```
- I'm aliasing `[]` to `fetch` to not break anything.
