### PR TITLE
Call .to_sym on a key object before fetching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :console do
 end
 
 group :test do
-  gem 'activesupport'
+  gem 'activesupport', '~> 4.2'
   gem 'inflecto', '~> 0.0', '>= 0.0.2'
 
   platforms :rbx do

--- a/lib/rom/support/registry.rb
+++ b/lib/rom/support/registry.rb
@@ -23,11 +23,11 @@ module ROM
     end
 
     def key?(name)
-      elements.key?(name)
+      elements.key?(name.to_sym)
     end
 
     def fetch(key)
-      elements.fetch(key) do
+      elements.fetch(key.to_sym) do
         return yield if block_given?
 
         raise ElementNotFoundError.new(key, name)

--- a/spec/unit/rom/support/registry_spec.rb
+++ b/spec/unit/rom/support/registry_spec.rb
@@ -18,6 +18,10 @@ shared_examples_for 'registry fetch' do
 
     expect(value).to eq(:twix)
   end
+
+  it 'calls #to_sym on a key before fetching' do
+    expect(registry.public_send(fetch_method, double(to_sym: :mars))).to be(mars)
+  end
 end
 
 describe ROM::Registry do


### PR DESCRIPTION
We're going to leverage this in ROM::RelationRegistry. The change is tiny and shouldn't affect anything
