### PR TITLE
Do not load constants

### DIFF
--- a/lib/rom-support.rb
+++ b/lib/rom-support.rb
@@ -1,2 +1,1 @@
 require 'dry-equalizer'
-require 'rom/support/constants'

--- a/lib/rom/support/class_macros.rb
+++ b/lib/rom/support/class_macros.rb
@@ -3,6 +3,8 @@ module ROM
   #
   # @private
   module ClassMacros
+    UndefinedValue = Object.new
+
     # Specify what macros a class will use
     #
     # @example
@@ -29,14 +31,10 @@ module ROM
     def defines(*args)
       mod = Module.new do
         args.each do |name|
-          define_method(name) do |value = Undefined|
+          define_method(name) do |value = UndefinedValue|
             ivar = "@#{name}"
-            if value == Undefined
-              if instance_variable_defined?(ivar)
-                instance_variable_get(ivar)
-              else
-                nil
-              end
+            if value == UndefinedValue
+              defined?(ivar) && instance_variable_get(ivar)
             else
               instance_variable_set(ivar, value)
             end

--- a/lib/rom/support/class_macros.rb
+++ b/lib/rom/support/class_macros.rb
@@ -34,7 +34,11 @@ module ROM
           define_method(name) do |value = UndefinedValue|
             ivar = "@#{name}"
             if value == UndefinedValue
-              instance_variable_defined?(ivar) && instance_variable_get(ivar)
+              if instance_variable_defined?(ivar)
+                instance_variable_get(ivar)
+              else
+                nil
+              end
             else
               instance_variable_set(ivar, value)
             end

--- a/lib/rom/support/class_macros.rb
+++ b/lib/rom/support/class_macros.rb
@@ -34,7 +34,7 @@ module ROM
           define_method(name) do |value = UndefinedValue|
             ivar = "@#{name}"
             if value == UndefinedValue
-              defined?(ivar) && instance_variable_get(ivar)
+              instance_variable_defined?(ivar) && instance_variable_get(ivar)
             else
               instance_variable_set(ivar, value)
             end


### PR DESCRIPTION
As a part of killing this gem we stop to load ROM's constants and use dry-core's constants instead